### PR TITLE
fix: add numpy requirement

### DIFF
--- a/scrabble/requirements.txt
+++ b/scrabble/requirements.txt
@@ -1,3 +1,4 @@
 arcade
 colorama
 result
+numpy


### PR DESCRIPTION
**Problem:** the requirements file doesn't have numpy but it's required.

**Solution:** add numpy to the requirements file

<img width="961" alt="image" src="https://github.com/codereport/scrabble/assets/39951657/7e4abcec-b4ef-449c-9fa3-d78a7f456053">
