### PR TITLE
FEATURE: Add 15:00 Timer

### DIFF
--- a/scrabble/python/main.py
+++ b/scrabble/python/main.py
@@ -503,7 +503,7 @@ class MyGame(arcade.Window):
 
         # Draw top word boxes
         play_index = 1
-        for row in reversed(range(ROW_COUNT - 1)):
+        for row in reversed(range(ROW_COUNT - 2)):
             render_row = 14 - row # and place
             if len(self.player_plays) == 0 or render_row + 1 > len(self.player_plays):
                 continue
@@ -643,7 +643,7 @@ class MyGame(arcade.Window):
                 self.current_time -= 1
             else:
                 # Time is up! Treat this as a pass/exchange and switch turns.
-                self.setup_for_computers_turn(Exchange.NO)
+                self.setup_for_computers_turn(Exchange.YES)
                 self.current_time = self.time_limit # Reset timer for computer's "turn" (it's quick)
 
     def reset_timer(self):


### PR DESCRIPTION
New Feature: Turn Timer
A 15-minute timer has been added to limit the time a player has to complete their turn.
Key Details

-  Time Limit: Each player turn is allotted 15 minutes (00:00).
-  Display: The timer is displayed on the right side of the screen, just above the word ranking boxes.
-  Action on Expiration: If the timer reaches 00:00, the current player's turn is immediately ended, and the computer's turn begins (treated as a pass/exchange).
-  Timer Reset: The timer automatically resets to 15:00 at the start of every player's turn (after the computer plays, or after the player successfully submits a word).

Timer Controls
| Action | Key | Notes |
| Pass/End Turn | ENTER | Submitting a valid word resets the timer. |
| Exchange | BACKSLASH | Initiating an exchange of tiles resets the timer. |